### PR TITLE
fixed bug where playername was same as host name

### DIFF
--- a/quizlambd/server/socketHandlers/createRoom.js
+++ b/quizlambd/server/socketHandlers/createRoom.js
@@ -5,7 +5,7 @@ const roomManager = require('../managers/roomManager');
 
 function handleCreateRoom(socket, data, callback) {
   console.log(data)
-  const room = roomManager.createRoom(socket.id, data.playerName);
+  const room = roomManager.createRoom(data.playerName);
 
   socket.join(room.roomCode);
   socket.emit('roomCreated', { roomId: room.roomCode });


### PR DESCRIPTION
createroom function call in createRoom.js socket handler was sending socket id as first parameter and hostName as second, whereas the function in the roomManager.js was expecting just the hostName. Removed the socket.id parameter and verified the host name was the name given by the player and not the host ID